### PR TITLE
fix: Update goreleaser GH workflow to be up to date

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,7 +6,7 @@ name: Release
 on:
   push:
     tags:
-      - "v*"
+      - 'v*'
 
 # Releases need permissions to read and write the repository contents.
 # GitHub considers creating releases and uploading assets as writing contents.
@@ -18,29 +18,30 @@ jobs:
     name: "lint and test"
     secrets: inherit
     uses: ./.github/workflows/lint-test.yml
-  release:
+
+  goreleaser:
     needs:
       - lint-test
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           # Allow goreleaser to access older tag information.
           fetch-depth: 0
-      - uses: actions/setup-go@v3
+      - uses: actions/setup-go@f111f3307d8850f501ac008e886eec1fd1932a34 # v5.3.0
         with:
-          go-version-file: "go.mod"
+          go-version-file: 'go.mod'
           cache: true
       - name: Import GPG key
-        uses: crazy-max/ghaction-import-gpg@v5
+        uses: crazy-max/ghaction-import-gpg@cb9bde2e2525e640591a934b1fd28eef1dcaf5e5 # v6.2.0
         id: import_gpg
         with:
           gpg_private_key: ${{ secrets.GPG_PRIVATE_KEY }}
           passphrase: ${{ secrets.PASSPHRASE }}
       - name: Run GoReleaser
-        uses: goreleaser/goreleaser-action@v3
+        uses: goreleaser/goreleaser-action@90a3faa9d0182683851fbfa97ca1a2cb983bfca3 # v6.2.1
         with:
-          args: release --rm-dist
+          args: release --clean
         env:
           # GitHub sets the GITHUB_TOKEN secret automatically.
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,5 +1,6 @@
 # Visit https://goreleaser.com for documentation on how to customize this
 # behavior.
+version: 2
 before:
   hooks:
     # this is just an example and not a requirement for provider building/publishing
@@ -7,7 +8,7 @@ before:
 builds:
 - env:
     # goreleaser does not work with CGO, it could also complicate
-    # usage by users in CI/CD systems like Terraform Cloud where
+    # usage by users in CI/CD systems like HCP Terraform where
     # they are unable to install libraries.
     - CGO_ENABLED=0
   mod_timestamp: '{{ .CommitTimestamp }}'
@@ -41,7 +42,7 @@ checksum:
 signs:
   - artifacts: checksum
     args:
-      # if you are using this in a GitHub action or some other automated pipeline, you 
+      # if you are using this in a GitHub action or some other automated pipeline, you
       # need to pass the batch flag to indicate its not interactive.
       - "--batch"
       - "--local-user"
@@ -57,4 +58,4 @@ release:
   # If you want to manually examine the release before its live, uncomment this line:
   # draft: true
 changelog:
-  skip: true
+  disable: true

--- a/go.sum
+++ b/go.sum
@@ -311,8 +311,6 @@ github.com/jmespath/go-jmespath/internal/testify v1.5.1 h1:shLQSRRSCCPj3f2gpwzGw
 github.com/jmespath/go-jmespath/internal/testify v1.5.1/go.mod h1:L3OGu8Wl2/fWfCI6z80xFu9LTZmf1ZRjMHUOPmWr69U=
 github.com/json-iterator/go v1.1.12 h1:PV8peI4a0ysnczrg+LtxykD8LfKY9ML6u2jnxaEnrnM=
 github.com/json-iterator/go v1.1.12/go.mod h1:e30LSqwooZae/UwlEbR2852Gd8hjQvJoHmT4TnhNGBo=
-github.com/keboola/go-client v1.29.1-0.20250319094049-d850c86d3dbc h1:zsMjW/a3422i8AiUqX7RPm21Z7Bq+vniFUdbYPGksn0=
-github.com/keboola/go-client v1.29.1-0.20250319094049-d850c86d3dbc/go.mod h1:yNNM+IlJaiptUsRjiMjUs998T7OT0qu/FiJyJf/EOGY=
 github.com/keboola/go-client v1.29.1-0.20250324082202-76e07013fb18 h1:37YWwF27L797Ri3yFPc8kKyXXT4goBo8Mrmk3iwSyM0=
 github.com/keboola/go-client v1.29.1-0.20250324082202-76e07013fb18/go.mod h1:yNNM+IlJaiptUsRjiMjUs998T7OT0qu/FiJyJf/EOGY=
 github.com/keboola/go-utils v1.3.0 h1:oiNRfUlLFTWjATty4oQlCBWmiMZN80QCCnRHP61Md5Q=


### PR DESCRIPTION
* Update GH actions workflow based on scaffold https://github.com/hashicorp/terraform-provider-scaffolding-framework/blob/main/.github/workflows/release.yml
* Update goreleaser based on scaffold https://github.com/hashicorp/terraform-provider-scaffolding-framework/blob/main/.goreleaser.yml